### PR TITLE
Bug fix in Minerva report

### DIFF
--- a/Docker/base_Dockerfile
+++ b/Docker/base_Dockerfile
@@ -10,8 +10,8 @@ RUN rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.
 RUN yum -y install python-pip && pip install -U pip
 
 # Copy in our RPM and install it
-COPY gracc-reporting-0.11-3.noarch.rpm /tmp
-RUN yum -y install /tmp/gracc-reporting-0.11-3.noarch.rpm
+COPY gracc-reporting-0.11.4.noarch.rpm /tmp
+RUN yum -y install /tmp/gracc-reporting-0.11.4.noarch.rpm
 
 # Remove python-urllib3, install PyPi urllib3.  Eventually, hopefully this will go away
 RUN rpm -qa | grep python-urllib3 | xargs rpm -e --nodeps && pip install urllib3

--- a/Docker/efficiencyreport_Dockerfile
+++ b/Docker/efficiencyreport_Dockerfile
@@ -1,5 +1,5 @@
 # FIFE base image for gracc-reporting
-FROM shreyb/gracc-reporting:fife_0.11-3
+FROM shreyb/gracc-reporting:fife_0.11.4
 
 # Run executable 
 ENTRYPOINT ["efficiencyreport"] 

--- a/Docker/fife_Dockerfile
+++ b/Docker/fife_Dockerfile
@@ -1,5 +1,5 @@
 #gracc-reporting base image
-FROM shreyb/gracc-reporting:base_0.11-3
+FROM shreyb/gracc-reporting:base_0.11.4
 
 # ifmon user setup 
 ENV MYGID 1003

--- a/Docker/jobsuccessratereport_Dockerfile
+++ b/Docker/jobsuccessratereport_Dockerfile
@@ -1,5 +1,5 @@
 # FIFE base image for gracc-reporting
-FROM shreyb/gracc-reporting:fife_0.11-3
+FROM shreyb/gracc-reporting:fife_0.11.4
 
 # Run executable 
 ENTRYPOINT ["jobsuccessratereport"]

--- a/Docker/minervareport_Dockerfile
+++ b/Docker/minervareport_Dockerfile
@@ -1,5 +1,5 @@
 # FIFE base image for gracc-reporting
-FROM shreyb/gracc-reporting:fife_0.11-3
+FROM shreyb/gracc-reporting:fife_0.11.4
 
 # Run executable 
 ENTRYPOINT ["minervareport"]

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ if sys.version_info < version_tuple:
     exit(1)
 
 setup(name='gracc-reporting',
-      version='0.11.3',
+      version='0.11.4',
       description='GRACC Email Reports',
       author_email='sbhat@fnal.gov',
       author='Shreyas Bhat',

--- a/src/graccreports/config/gracc-reporting.spec
+++ b/src/graccreports/config/gracc-reporting.spec
@@ -1,7 +1,7 @@
 %define name gracc-reporting
 %define version 0.11
 %define unmangled_version 0.11
-%define release 3
+%define release 4
 
 Summary: 	GRACC Email Reports
 Name: 		%{name}

--- a/src/graccreports/config/gracc-reporting.spec
+++ b/src/graccreports/config/gracc-reporting.spec
@@ -1,7 +1,8 @@
 %define name gracc-reporting
-%define version 0.11
-%define unmangled_version 0.11
-%define release 4
+%define version 0.11.4
+%define unmangled_version 0.11.4
+%define release 1
+%define _rpmfilename %%{ARCH}/%%{NAME}-%%{VERSION}.%%{ARCH}.rpm
 
 Summary: 	GRACC Email Reports
 Name: 		%{name}

--- a/src/graccreports/minerva_report/CurrentJobs.py
+++ b/src/graccreports/minerva_report/CurrentJobs.py
@@ -61,30 +61,43 @@ class CurrentJobs:
                                               "FIFEMON_ACCESS: %sDOWN%s" % (color_red, end_color) )
         self.template = self.template.replace("$CURRENT_JOBS_LEVEL_1_STARTS", "" if self.access_fifemon else "<!-- ")
         if self.access_fifemon:
-            current = self.jobs['current'].get_average_jobs()
-            idle = self.jobs['idle'].get_average_jobs()
-            held = self.jobs['held'].get_average_jobs()
-            if current < self.limit*0.75 and current < idle/2.:
+            jobtype_dict = {'current': None, 'idle': None, 'held': None}
+
+            for t in jobtype_dict:
+                try:
+                    jobtype_dict[t] = self.jobs[t].get_average_jobs()
+                except KeyError:
+                    pass
+
+            if (jobtype_dict['current'] is not None
+                and jobtype_dict['idle'] is not None) and \
+                    (jobtype_dict['current'] < self.limit*0.75
+                     and jobtype_dict['current'] < jobtype_dict['idle']/2.):
                 color_used = color_red
             else:
                 color_used = color_black
-            if held > self.held_limit:
+
+            if jobtype_dict['held'] is not None and \
+                            jobtype_dict['held'] > self.held_limit:
                 color_held = color_red
             else:
                 color_held = color_black
-            current = self.jobs['current'].get_average_jobs()
-            idle = self.jobs['idle'].get_average_jobs()
-            held = self.jobs['held'].get_average_jobs()
+
+            # Any classification of jobs that have "None" in the dict should
+            # be changed to 0
+            for key in jobtype_dict:
+                if jobtype_dict[key] is None:
+                    jobtype_dict[key] = 0
+
             table_content = "%s<tr><td align=\"right\">%s%s%s</td><td align=\"right\">" \
                             "%s%s%s</td><td align=\"right\">%s%s%s</td></tr>" % \
-                            (table_content, color_used, current, end_color, color_used, idle, end_color,
-                             color_held, held, end_color)
+                            (table_content, color_used,
+                             jobtype_dict['current'], end_color,
+                             color_used, jobtype_dict['idle'], end_color,
+                             color_held, jobtype_dict['held'], end_color)
             self.template = self.template.replace("$TABLE_CURRENT_JOBS", table_content)
         self.template = self.template.replace("$CURRENT_JOBS_LEVEL_1_ENDS", "" if self.access_fifemon else "-->")
         return self.template
-
-
-
 
 
 def parse_opts():


### PR DESCRIPTION
The CurrentJobs module had a bug so that if there were no jobs for Minerva that fit any of the types (Current, Idle, Held), the report would crash with a KeyError.  I put in checks to have those counts default to 0.

I also updated the spec file and changed the Docker Images versioning so that the RPM and Docker Images match the python versioning (x.x.x).