### PR TITLE
Add clause to TextUtils.sendEmail to allow for HTML-only reports

### DIFF
--- a/gracc_reporting/TextUtils.py
+++ b/gracc_reporting/TextUtils.py
@@ -96,6 +96,8 @@ def sendEmail(toList, subject, content, fromEmail=None, smtpServerHost=None, htm
     if "text" in content:
         msg.set_content(content["text"], 'plain')
         msg.add_alternative("<pre>" + content["text"] + "</pre>", subtype="html")
+	elif "html" in content and "text" not in content:
+        msg.add_alternative(content["html"], subtype="html")
 
     if html_template:
         attachment_html = content["html"]

--- a/gracc_reporting/TextUtils.py
+++ b/gracc_reporting/TextUtils.py
@@ -96,7 +96,7 @@ def sendEmail(toList, subject, content, fromEmail=None, smtpServerHost=None, htm
     if "text" in content:
         msg.set_content(content["text"], 'plain')
         msg.add_alternative("<pre>" + content["text"] + "</pre>", subtype="html")
-	elif "html" in content and "text" not in content:
+    elif "html" in content and "text" not in content:
         msg.add_alternative(content["html"], subtype="html")
 
     if html_template:


### PR DESCRIPTION
With the upgrade to python3, gracc-reporting seems to have lost the ability to allow for multipart report emails where only an HTML block was given to `sendEmail`.  This is a feature we use for all of the FIFE reports at Fermilab - we generate the HTML from external templates that are packaged with the reports - so I believe the addition of these two lines would allow for such emails to be sent.

Please let me know what you all think or if you have any questions.  


Draft status:  
1. Draft until I verify with all FIFE reports that this works.  I've verified with our Job Efficiency Report, but there are two more reports I'd like to verify before marking this ready.
2. I have not tested this change with the OSG reports - if you think I should do that before marking this PR ready for review, I'm happy to do so.
