### PR TITLE
Allow queries against GRACC when in yellow status

### DIFF
--- a/gracc_reporting/ReportUtils.py
+++ b/gracc_reporting/ReportUtils.py
@@ -390,7 +390,7 @@ class Reporter(object, metaclass=abc.ABCMeta):
 
         :return: elasticsearch.Elasticsearch object
         """
-        _fallback_ok = ['green', ]
+        _fallback_ok = ['green', 'yellow']
         _default_host = 'https://gracc.opensciencegrid.org/q'
 
         if self.verbose:


### PR DESCRIPTION
Yellow status means the cluster is not allocated correctly, not that there is any missing data.